### PR TITLE
Fix user avatar migration

### DIFF
--- a/js/src/admin/components/MybbToFlarumPage.js
+++ b/js/src/admin/components/MybbToFlarumPage.js
@@ -164,7 +164,7 @@ export default class MybbToFlarumPage extends Page {
 			'mybb_password': this.mybb.password(),
 			'mybb_db': this.mybb.db(),
 			'mybb_prefix': this.mybb.prefix(),
-			'mybb_path': this.mybb.mybbPath()
+			'mybb_path': (this.mybb.mybbPath().endsWith('/') ? this.mybb.mybbPath() : this.mybb.mybbPath() + '/')
 		}).then(() => {
 			app.request({
 				method: 'POST',

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -107,10 +107,6 @@ class Migrator
 
 				if($migrateAvatars && !empty($this->getMybbPath()) && !empty($row->avatar))
 				{
-					if (substr($this->getMybbPath(), strlen($this->getMybbPath())-1, 1) !== '/') {
-						$this->mybb_path = $this->getMybbPath().'/';
-					}
-
 					$fullpath = $this->getMybbPath().explode("?", $row->avatar)[0];
 					$avatar = basename($fullpath);
 

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -27,7 +27,7 @@ class Migrator
 		"posts" => 0
 	];
 
-	const FLARUM_AVATAR_PATH = "assets/avatars/";
+	const FLARUM_AVATAR_PATH = __DIR__ . "/../../../../public/assets/avatars/";
 
 	/**
 	 * Migrator constructor
@@ -106,8 +106,15 @@ class Migrator
 
 				if($migrateAvatars && !empty($this->getMybbPath()) && !empty($row->avatar))
 				{
-					$fullpath = $this->getMybbPath().explode("?", $row->avatar)[0];
+					$mybbAvatarPath = explode("?", $row->avatar)[0];
+
+					if (substr($mybbAvatarPath, 0 , 1) === '.') {
+						$mybbAvatarPath = substr($mybbAvatarPath, 1);
+					}
+
+					$fullpath = $this->getMybbPath().$mybbAvatarPath;
 					$avatar = basename($fullpath);
+
 					if(file_exists($fullpath))
 					{
 						if(copy($fullpath,self::FLARUM_AVATAR_PATH.$avatar))

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -27,7 +27,7 @@ class Migrator
 		"posts" => 0
 	];
 
-	const FLARUM_AVATAR_PATH = __DIR__ . "/../../../../public/assets/avatars/";
+	const FLARUM_AVATAR_PATH = "assets/avatars/";
 
 	/**
 	 * Migrator constructor

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -109,7 +109,6 @@ class Migrator
 				{
 					$fullpath = $this->getMybbPath().explode("?", $row->avatar)[0];
 					$avatar = basename($fullpath);
-
 					if(file_exists($fullpath))
 					{
 						if(copy($fullpath,self::FLARUM_AVATAR_PATH.$avatar))

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -106,13 +106,11 @@ class Migrator
 
 				if($migrateAvatars && !empty($this->getMybbPath()) && !empty($row->avatar))
 				{
-					$mybbAvatarPath = explode("?", $row->avatar)[0];
-
-					if (substr($mybbAvatarPath, 0 , 1) === '.') {
-						$mybbAvatarPath = substr($mybbAvatarPath, 1);
+					if (substr($this->getMybbPath(), strlen($this->getMybbPath())-1, 1) !== '/') {
+						$this->mybb_path = $this->getMybbPath().'/';
 					}
 
-					$fullpath = $this->getMybbPath().$mybbAvatarPath;
+					$fullpath = $this->getMybbPath().explode("?", $row->avatar)[0];
 					$avatar = basename($fullpath);
 
 					if(file_exists($fullpath))

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -99,6 +99,7 @@ class Migrator
 				);
 
 				$newUser->activate();
+				$newUser->id = $row->uid;
 				$newUser->joined_at = $row->regdate;
 				$newUser->last_seen_at = $row->lastvisit;
 				$newUser->discussion_count = $row->threadnum;


### PR DESCRIPTION
The migration of user avatars is not working correctly due to the path of the avatar containing a `.` at the beginning.

This is the path of an avatar in myBB: `./uploads/avatars/avatar_1.png?dateline=1419957458`. When that is added to the `mybb_path` this would look like this: `/var/www/forum./uploads/avatars/avatar_1.png` and the `file_exists($fullpath)` will fail. By checking for the `.` and removing it if necessary this is fixed.