### PR TITLE
Do not import threads without posts

### DIFF
--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -259,12 +259,16 @@ class Migrator
 					$this->count["posts"]++;					
 				}
 
-				$discussion->setFirstPost($firstPost);
-				$discussion->refreshCommentCount();
-				$discussion->refreshLastPost();
-				$discussion->refreshParticipantCount();
+                if (is_null($firstPost)) {
+                    $discussion->delete();
+                } else {
+                    $discussion->setFirstPost($firstPost);
+                    $discussion->refreshCommentCount();
+                    $discussion->refreshLastPost();
+                    $discussion->refreshParticipantCount();
 
-				$discussion->save();
+                    $discussion->save();
+                }
 			}
 
 			if($migrateWithUsers)


### PR DESCRIPTION
When I did migration from my myBB instance to Flarum, I encountered error when there is thread with no posts. I don't know how that could happen, but this will fix it by deleting partially imported thread when there are no posts in it.